### PR TITLE
Update pom.xml.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
             <dependency>
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
-                <version>3.2.1</version>
+                <version>3.2.2</version>
             </dependency>
             <dependency>
                 <groupId>org.rrd4j</groupId>


### PR DESCRIPTION
3.2.1 has a CVSS 10.0 vulnerability. By simply being on the class path it makes serialization for the entire JVM process vulnerable to remote code execution. 3.2.2 fixes the issue.
